### PR TITLE
fix(json-ld): missing from head

### DIFF
--- a/ui/src/components/JsonLd.tsx
+++ b/ui/src/components/JsonLd.tsx
@@ -1,4 +1,3 @@
-import Head from 'next/head';
 interface JsonLdProps {
   data: object | object[];
 }
@@ -9,7 +8,7 @@ interface JsonLdProps {
  */
 export function JsonLd({ data }: JsonLdProps) {
   return (
-    <Head>
+    <>
       <script
         id={`jsonld`}
         type="application/ld+json"
@@ -17,6 +16,6 @@ export function JsonLd({ data }: JsonLdProps) {
           __html: JSON.stringify(data).replace(/</g, '\\u003c'),
         }}
       />
-    </Head>
+    </>
   );
 }


### PR DESCRIPTION
This pull request makes a minor update to the `JsonLd` component, simplifying its implementation by removing its dependency on the `Head` component.

* Removed the import and usage of `Head` from `next/head` in `ui/src/components/JsonLd.tsx`, replacing it with a fragment to wrap the JSON-LD script. [[1]](diffhunk://#diff-7a37250e57c3199677db99fdc0ec22484e51dfdffa2052566384340564b5e09eL1) [[2]](diffhunk://#diff-7a37250e57c3199677db99fdc0ec22484e51dfdffa2052566384340564b5e09eL12-R19)