### PR TITLE
feat(metadata): add robots and sitemap + jsonld

### DIFF
--- a/ui/src/app/blog/[slug]/page.tsx
+++ b/ui/src/app/blog/[slug]/page.tsx
@@ -7,6 +7,8 @@ import { BlogPostCard } from '@/ui/BlogPostCard';
 import { Typography } from '@/ui/Typography';
 import { getPostBySlug, getRelatedPosts, getAllPosts } from '@/lib/blog-utils';
 import { renderMarkdown } from '@/lib/markdown-utils';
+import { JsonLd } from '@/components/JsonLd';
+import { blogPostJsonLd } from '@/lib/jsonld';
 
 interface BlogPostPageProps {
   params: Promise<{
@@ -70,6 +72,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
 
   return (
     <>
+      <JsonLd data={blogPostJsonLd(post)} />
       <NavBar />
       <div className="min-h-screen pb-28 pt-20">
         <div className="container mx-auto px-4">

--- a/ui/src/app/blog/page.tsx
+++ b/ui/src/app/blog/page.tsx
@@ -6,6 +6,8 @@ import { BlogPagination } from '@/ui/BlogPagination';
 import { getPaginatedPosts, getAllTags } from '@/lib/blog-utils';
 import { BlogSearchParams } from '@/lib/blog-types';
 import { Suspense } from 'react';
+import { JsonLd } from '@/components/JsonLd';
+import { blogPageJsonLd } from '@/lib/jsonld';
 
 import type { Metadata } from 'next';
 
@@ -96,6 +98,7 @@ async function BlogPageContent({ searchParams }: BlogPageProps) {
 export default function BlogPage({ searchParams }: BlogPageProps) {
   return (
     <>
+      <JsonLd data={blogPageJsonLd()} />
       <NavBar />
       <div className="min-h-screen pb-28 pt-20">
         <div className="container mx-auto px-4 md:px-8 lg:px-16">

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -38,7 +38,6 @@ export const metadata: Metadata = {
   alternates: {
     canonical: '/',
   },
-  themeColor: '#008000', // change to your brand color
 };
 
 export default function RootLayout({

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -5,6 +5,8 @@ import { SocialLinks } from '@/ui/SocialLinks';
 import { NavBar } from '@/ui/navbar/NavBar';
 import { BlogShowcase } from '@/ui/BlogShowcase';
 import { ProjectShowcase } from '@/ui/ProjectShowcase';
+import { JsonLd } from '@/components/JsonLd';
+import { homepageJsonLd } from '@/lib/jsonld';
 
 export default function Home() {
   const HeroTitle = (
@@ -18,6 +20,7 @@ export default function Home() {
 
   return (
     <>
+      <JsonLd data={homepageJsonLd()} />
       <NavBar />
       <div className="mb-28 flex justify-center md:mb-0">
         <div className="container">

--- a/ui/src/app/projects/page.tsx
+++ b/ui/src/app/projects/page.tsx
@@ -2,13 +2,20 @@ import { NavBar } from '@/ui/navbar/NavBar';
 import { Typography } from '@/ui/Typography';
 import { Suspense } from 'react';
 import { ProjectSearchParams } from '@/lib/project-types';
-import { getPaginatedProjects, getAllTech, getHighlightedProjects } from '@/lib/project-utils';
+import {
+  getPaginatedProjects,
+  getAllTech,
+  getHighlightedProjects,
+  getAllProjects,
+} from '@/lib/project-utils';
 import { ProjectCard } from '@/ui/ProjectCard';
 import { ProjectFilters } from '@/ui/ProjectFilters';
 import { ProjectHighlightCarousel } from '@/ui/ProjectHighlightCarousel';
 import { BlogPagination } from '@/ui/BlogPagination';
 import type { PaginatedBlogPosts } from '@/lib/blog-types';
 import Link from 'next/link';
+import { JsonLd } from '@/components/JsonLd';
+import { projectsPageJsonLd } from '@/lib/jsonld';
 
 import type { Metadata } from 'next';
 
@@ -81,8 +88,11 @@ async function ProjectsPageContent({ searchParams }: ProjectsPageProps) {
 }
 
 export default function ProjectsPage({ searchParams }: ProjectsPageProps) {
+  const allProjects = getAllProjects();
+
   return (
     <>
+      <JsonLd data={projectsPageJsonLd(allProjects)} />
       <NavBar />
       <div className="min-h-screen pb-28 pt-20">
         <div className="container mx-auto px-4 md:px-8 lg:px-16">

--- a/ui/src/app/robots.ts
+++ b/ui/src/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: 'https://insuasti.com/sitemap.xml',
+  };
+}

--- a/ui/src/app/sitemap.ts
+++ b/ui/src/app/sitemap.ts
@@ -1,0 +1,39 @@
+import type { MetadataRoute } from 'next';
+import { getAllPosts } from '@/lib/blog-utils';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = 'https://insuasti.com';
+
+  // Static routes
+  const staticRoutes: MetadataRoute.Sitemap = [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/projects`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+    {
+      url: `${baseUrl}/blog`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    },
+  ];
+
+  // Dynamic blog routes
+  const blogPosts = getAllPosts();
+  const blogRoutes: MetadataRoute.Sitemap = blogPosts.map((post) => ({
+    url: `${baseUrl}/blog/${post.slug}`,
+    lastModified: new Date(post.date),
+    changeFrequency: 'monthly' as const,
+    priority: 0.7,
+  }));
+
+  return [...staticRoutes, ...blogRoutes];
+}

--- a/ui/src/components/JsonLd.tsx
+++ b/ui/src/components/JsonLd.tsx
@@ -1,0 +1,21 @@
+interface JsonLdProps {
+  data: object | object[];
+}
+
+/**
+ * Component for rendering JSON-LD structured data
+ * Accepts either a single schema object or an array of schema objects
+ */
+export function JsonLd({ data }: JsonLdProps) {
+  return (
+    <>
+      <script
+        id={`jsonld`}
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(data).replace(/</g, '\\u003c'),
+        }}
+      />
+    </>
+  );
+}

--- a/ui/src/lib/jsonld/README.md
+++ b/ui/src/lib/jsonld/README.md
@@ -1,0 +1,83 @@
+# JSON-LD Structured Data
+
+This directory contains JSON-LD structured data schemas for different pages of the site. These schemas help search engines understand the content and improve SEO.
+
+## Available Schemas
+
+### Homepage (`homepage.ts`)
+
+- **Schema Types**: `Person`, `WebSite`
+- **Usage**: `import { homepageJsonLd } from '@/lib/jsonld'`
+- **Description**: Describes Juan Insuasti as a person and the website
+
+### Blog Page (`blog-page.ts`)
+
+- **Schema Types**: `Blog`, `WebPage`
+- **Usage**: `import { blogPageJsonLd } from '@/lib/jsonld'`
+- **Description**: Describes the blog listing page and blog itself
+
+### Blog Post (`blog-post.ts`)
+
+- **Schema Types**: `BlogPosting`, `WebPage`, `Article`
+- **Usage**: `import { blogPostJsonLd } from '@/lib/jsonld'`
+- **Description**: Describes individual blog posts with metadata
+- **Parameters**: Requires a `BlogPost` object
+
+### Projects Page (`projects-page.ts`)
+
+- **Schema Types**: `CollectionPage`, `WebPage`
+- **Usage**: `import { projectsPageJsonLd } from '@/lib/jsonld'`
+- **Description**: Describes the projects page and featured projects
+- **Parameters**: Optional array of `ProjectMeta` objects
+
+## Usage Example
+
+```tsx
+import { JsonLd } from '@/components/JsonLd';
+import { homepageJsonLd } from '@/lib/jsonld';
+
+export default function HomePage() {
+  return (
+    <>
+      <JsonLd data={homepageJsonLd()} />
+      {/* Rest of your page content */}
+    </>
+  );
+}
+```
+
+## JsonLd Component
+
+The `JsonLd` component located in `@/components/JsonLd` handles the rendering of JSON-LD data. It accepts either a single schema object or an array of schema objects.
+
+```tsx
+<JsonLd data={schemaData} />
+```
+
+## Schema.org Types Used
+
+- **Person**: For author/developer information
+- **WebSite**: For website-level information
+- **Blog**: For the blog as a whole
+- **BlogPosting**: For individual blog posts
+- **Article**: Alternative representation for blog posts
+- **WebPage**: For individual pages
+- **CollectionPage**: For pages that list collections (projects)
+- **CreativeWork**: For projects and portfolio items
+- **BreadcrumbList**: For navigation breadcrumbs
+
+## Best Practices
+
+1. Always include breadcrumbs for navigation hierarchy
+2. Use consistent URL formatting (https://insuasti.com)
+3. Include relevant keywords and descriptions
+4. Ensure dates are in ISO format
+5. Link related entities using the same identifiers
+
+## Validation
+
+You can validate the JSON-LD output using:
+
+- [Google Rich Results Test](https://search.google.com/test/rich-results)
+- [Schema Markup Validator](https://validator.schema.org/)
+- [JSON-LD Playground](https://json-ld.org/playground/)

--- a/ui/src/lib/jsonld/blog-page.ts
+++ b/ui/src/lib/jsonld/blog-page.ts
@@ -1,0 +1,72 @@
+/**
+ * JSON-LD schema for the blog listing page
+ * Includes Blog and WebPage schemas
+ */
+export const blogPageJsonLd = () => {
+  return [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Blog',
+      name: 'Insuasti Blog',
+      url: 'https://insuasti.com/blog',
+      description:
+        'Articles on web development, electronics, and creative problem-solving. A mix of brain dumps, tech notes, and deep dives into frontend, web technologies, and electronics.',
+      author: {
+        '@type': 'Person',
+        name: 'Juan Insuasti',
+        url: 'https://insuasti.com/',
+      },
+      publisher: {
+        '@type': 'Person',
+        name: 'Juan Insuasti',
+        url: 'https://insuasti.com/',
+      },
+      inLanguage: 'en-US',
+      keywords: [
+        'web development',
+        'frontend',
+        'React',
+        'TypeScript',
+        'Next.js',
+        'electronics',
+        'IoT',
+        'programming',
+        'tech articles',
+      ],
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'WebPage',
+      name: 'Blog | insuasti.com',
+      url: 'https://insuasti.com/blog',
+      description: 'Articles on web development, electronics, and creative problem-solving.',
+      isPartOf: {
+        '@type': 'WebSite',
+        name: 'Juan Insuasti | insuasti.com',
+        url: 'https://insuasti.com/',
+      },
+      author: {
+        '@type': 'Person',
+        name: 'Juan Insuasti',
+        url: 'https://insuasti.com/',
+      },
+      breadcrumb: {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          {
+            '@type': 'ListItem',
+            position: 1,
+            name: 'Home',
+            item: 'https://insuasti.com/',
+          },
+          {
+            '@type': 'ListItem',
+            position: 2,
+            name: 'Blog',
+            item: 'https://insuasti.com/blog',
+          },
+        ],
+      },
+    },
+  ];
+};

--- a/ui/src/lib/jsonld/blog-post.ts
+++ b/ui/src/lib/jsonld/blog-post.ts
@@ -1,0 +1,114 @@
+import { BlogPost } from '../blog-types';
+
+/**
+ * JSON-LD schema for individual blog posts
+ * Includes BlogPosting, WebPage, and Article schemas
+ */
+export const blogPostJsonLd = (post: BlogPost) => {
+  return [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'BlogPosting',
+      headline: post.title,
+      description: post.excerpt,
+      url: `https://insuasti.com/blog/${post.slug}`,
+      datePublished: post.publish || post.date,
+      dateModified: post.publish || post.date,
+      author: {
+        '@type': 'Person',
+        name: post.author || 'Juan Insuasti',
+        url: 'https://insuasti.com/',
+      },
+      publisher: {
+        '@type': 'Person',
+        name: 'Juan Insuasti',
+        url: 'https://insuasti.com/',
+      },
+      keywords: post.tags,
+      articleSection: 'Technology',
+      inLanguage: 'en-US',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': `https://insuasti.com/blog/${post.slug}`,
+      },
+      isPartOf: {
+        '@type': 'Blog',
+        name: 'Blog | insuasti.com',
+        url: 'https://insuasti.com/blog',
+      },
+      image: {
+        '@type': 'ImageObject',
+        url: 'https://insuasti.com/og.png?v=2',
+        width: 1200,
+        height: 630,
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'WebPage',
+      name: `${post.title} | Blog | Insuasti`,
+      url: `https://insuasti.com/blog/${post.slug}`,
+      description: post.excerpt,
+      isPartOf: {
+        '@type': 'WebSite',
+        name: 'Insuasti',
+        url: 'https://insuasti.com/',
+      },
+      author: {
+        '@type': 'Person',
+        name: post.author || 'Juan Insuasti',
+        url: 'https://insuasti.com/',
+      },
+      breadcrumb: {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          {
+            '@type': 'ListItem',
+            position: 1,
+            name: 'Home',
+            item: 'https://insuasti.com/',
+          },
+          {
+            '@type': 'ListItem',
+            position: 2,
+            name: 'Blog',
+            item: 'https://insuasti.com/blog',
+          },
+          {
+            '@type': 'ListItem',
+            position: 3,
+            name: post.title,
+            item: `https://insuasti.com/blog/${post.slug}`,
+          },
+        ],
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: post.title,
+      description: post.excerpt,
+      url: `https://insuasti.com/blog/${post.slug}`,
+      datePublished: post.publish || post.date,
+      dateModified: post.publish || post.date,
+      author: {
+        '@type': 'Person',
+        name: post.author || 'Juan Insuasti',
+        url: 'https://insuasti.com/',
+      },
+      publisher: {
+        '@type': 'Person',
+        name: 'Juan Insuasti',
+        url: 'https://insuasti.com/',
+      },
+      articleSection: post.tags.length > 0 ? post.tags[0] : 'Technology',
+      keywords: post.tags,
+      image: {
+        '@type': 'ImageObject',
+        url: 'https://insuasti.com/og.png?v=2',
+        width: 1200,
+        height: 630,
+      },
+    },
+  ];
+};

--- a/ui/src/lib/jsonld/homepage.ts
+++ b/ui/src/lib/jsonld/homepage.ts
@@ -1,0 +1,155 @@
+/**
+ * JSON-LD schema for the homepage
+ * Includes Person and WebSite schemas
+ */
+export const homepageJsonLd = () => {
+  return [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Person',
+      name: 'Juan Insuasti',
+      givenName: 'Juan',
+      familyName: 'Insuasti',
+      url: 'https://insuasti.com/',
+      email: 'juan.insuasti@gmail.com',
+      jobTitle: 'Senior Frontend Engineer',
+      description:
+        'Passionate about crafting helpful, delightful user experiences with a strong eye for detail. I work closely with design and product teams, building thoughtful experiences in cross-functional, multicultural environments.',
+      knowsAbout: [
+        'React',
+        'TypeScript',
+        'Next.js',
+        'Remix',
+        'GraphQL',
+        'REST',
+        'HTML',
+        'CSS',
+        'JavaScript',
+        'Sass',
+        'Tailwind CSS',
+        'CSS Modules',
+        'ReactQuery',
+        'Redux',
+        'Zustand',
+        'Jest',
+        'Vitest',
+        'Storybook',
+        'Cypress',
+        'Node.js',
+        'Vercel',
+        'AWS',
+        'Google Cloud',
+        'Docker',
+        'Accessibility',
+        'WCAG AA',
+        'UI/UX',
+        'Performance',
+        'Architecture',
+      ],
+      address: {
+        '@type': 'PostalAddress',
+        addressLocality: 'Medellín',
+        addressRegion: 'Antioquia',
+        addressCountry: 'CO',
+      },
+      sameAs: ['https://github.com/juan-insuasti', 'https://linkedin.com/in/jinsuasti'],
+      hasOccupation: {
+        '@type': 'Occupation',
+        name: 'Senior Frontend Engineer',
+        description:
+          'Building user-friendly web applications with a focus on performance and accessibility.',
+        occupationLocation: {
+          '@type': 'AdministrativeArea',
+          name: 'Medellín, Colombia',
+          address: {
+            '@type': 'PostalAddress',
+            addressLocality: 'Medellín',
+            addressRegion: 'Antioquia',
+            addressCountry: 'CO',
+          },
+        },
+      },
+      alumniOf: {
+        '@type': 'EducationalOrganization',
+        name: 'Universidad Javeriana',
+        location: {
+          '@type': 'Place',
+          name: 'Bogotá, Colombia',
+        },
+      },
+      hasCredential: {
+        '@type': 'EducationalOccupationalCredential',
+        credentialCategory: 'degree',
+        educationalLevel: 'undergraduate',
+        name: 'Electronic Engineer',
+        recognizedBy: {
+          '@type': 'EducationalOrganization',
+          name: 'Universidad Javeriana',
+        },
+      },
+      knowsLanguage: [
+        {
+          '@type': 'Language',
+          name: 'Spanish',
+        },
+        {
+          '@type': 'Language',
+          name: 'English',
+        },
+        {
+          '@type': 'Language',
+          name: 'Japanese',
+        },
+      ],
+      hasOfferCatalog: {
+        '@type': 'OfferCatalog',
+        name: 'Frontend Development Services',
+        itemListElement: [
+          {
+            '@type': 'Offer',
+            itemOffered: {
+              '@type': 'Service',
+              name: 'React Development',
+              description: 'Building scalable React applications with TypeScript',
+            },
+          },
+          {
+            '@type': 'Offer',
+            itemOffered: {
+              '@type': 'Service',
+              name: 'Next.js Development',
+              description: 'Full-stack Next.js applications with modern tooling',
+            },
+          },
+        ],
+      },
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        url: 'https://insuasti.com/',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'WebSite',
+      name: 'Juan Insuasti | insuasti.com',
+      alternateName: 'Insuasti',
+      url: 'https://insuasti.com/',
+      description:
+        'Portfolio and blog of Juan Insuasti, Senior Frontend Engineer specializing in React, TypeScript, Next.js, and modern web technologies.',
+      author: {
+        '@type': 'Person',
+        name: 'Juan Insuasti',
+        jobTitle: 'Senior Frontend Engineer',
+      },
+      publisher: {
+        '@type': 'Person',
+        name: 'Juan Insuasti',
+      },
+      inLanguage: ['en'],
+      mainEntity: {
+        '@type': 'Person',
+        name: 'Juan Insuasti',
+      },
+    },
+  ];
+};

--- a/ui/src/lib/jsonld/index.ts
+++ b/ui/src/lib/jsonld/index.ts
@@ -1,0 +1,20 @@
+/**
+ * JSON-LD schemas for different pages of the site
+ *
+ * Usage:
+ * - Homepage: import { homepageJsonLd } from '@/lib/jsonld'
+ * - Blog page: import { blogPageJsonLd } from '@/lib/jsonld'
+ * - Blog post: import { blogPostJsonLd } from '@/lib/jsonld'
+ * - Projects page: import { projectsPageJsonLd } from '@/lib/jsonld'
+ */
+
+export { homepageJsonLd } from './homepage';
+export { blogPageJsonLd } from './blog-page';
+export { blogPostJsonLd } from './blog-post';
+export { projectsPageJsonLd } from './projects-page';
+
+// Utility functions
+export * from './utils';
+
+// Legacy export for backward compatibility
+export { homepageJsonLd as jsonLd } from './homepage';

--- a/ui/src/lib/jsonld/projects-page.ts
+++ b/ui/src/lib/jsonld/projects-page.ts
@@ -1,0 +1,105 @@
+import { ProjectMeta } from '../project-types';
+
+/**
+ * JSON-LD schema for the projects page
+ * Includes CollectionPage and WebPage schemas
+ */
+export const projectsPageJsonLd = (projects: ProjectMeta[] = []) => {
+  const highlightedProjects = projects.filter((p) => p.highlighted).slice(0, 3);
+
+  return [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'CollectionPage',
+      name: 'Projects | Insuasti',
+      url: 'https://insuasti.com/projects',
+      description: "A curated selection of web and electronics projects I've built.",
+      author: {
+        '@type': 'Person',
+        name: 'Juan Insuasti',
+        url: 'https://insuasti.com/',
+      },
+      isPartOf: {
+        '@type': 'WebSite',
+        name: 'Insuasti',
+        url: 'https://insuasti.com/',
+      },
+      mainEntity: {
+        '@type': 'ItemList',
+        name: 'Featured Projects',
+        numberOfItems: highlightedProjects.length,
+        itemListElement: highlightedProjects.map((project, index) => ({
+          '@type': 'ListItem',
+          position: index + 1,
+          item: {
+            '@type': 'CreativeWork',
+            name: project.title,
+            description: project.summary,
+            url: project.demoUrl || project.repoUrl,
+            dateCreated: project.date,
+            creator: {
+              '@type': 'Person',
+              name: 'Juan Insuasti',
+              url: 'https://insuasti.com/',
+            },
+            keywords: project.tech,
+            image: {
+              '@type': 'ImageObject',
+              url: `https://insuasti.com${project.coverImage}`,
+            },
+            codeRepository: project.repoUrl,
+          },
+        })),
+      },
+      breadcrumb: {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          {
+            '@type': 'ListItem',
+            position: 1,
+            name: 'Home',
+            item: 'https://insuasti.com/',
+          },
+          {
+            '@type': 'ListItem',
+            position: 2,
+            name: 'Projects',
+            item: 'https://insuasti.com/projects',
+          },
+        ],
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'WebPage',
+      name: 'Projects | insuasti.com',
+      url: 'https://insuasti.com/projects',
+      description: "A curated selection of web and electronics projects I've built.",
+      isPartOf: {
+        '@type': 'WebSite',
+        name: 'Juan Insuasti | insuasti.com',
+        url: 'https://insuasti.com/',
+      },
+      author: {
+        '@type': 'Person',
+        name: 'Juan Insuasti',
+        url: 'https://insuasti.com/',
+      },
+      about: {
+        '@type': 'Thing',
+        name: 'Software Development Projects',
+        description: 'Portfolio of web development and electronics projects',
+      },
+      keywords: [
+        'projects',
+        'portfolio',
+        'React',
+        'TypeScript',
+        'Next.js',
+        'web development',
+        'electronics',
+        'open source',
+      ],
+    },
+  ];
+};

--- a/ui/src/lib/jsonld/test.ts
+++ b/ui/src/lib/jsonld/test.ts
@@ -1,0 +1,85 @@
+/**
+ * Simple validation test for JSON-LD schemas
+ * Run this file to check if all schemas generate valid JSON
+ */
+
+import { homepageJsonLd, blogPageJsonLd, blogPostJsonLd, projectsPageJsonLd } from './index';
+import type { BlogPost } from '../blog-types';
+import type { ProjectMeta } from '../project-types';
+
+// Mock data for testing
+const mockBlogPost: BlogPost = {
+  slug: 'test-post',
+  title: 'Test Blog Post',
+  date: '2025-01-01',
+  author: 'Juan Insuasti',
+  excerpt: 'This is a test blog post excerpt',
+  tags: ['test', 'example'],
+  content: 'This is the content of the test blog post',
+  publish: '2025-01-01',
+  highlighted: false,
+};
+
+const mockProjects: ProjectMeta[] = [
+  {
+    slug: 'test-project',
+    title: 'Test Project',
+    summary: 'This is a test project summary',
+    tech: ['React', 'TypeScript'],
+    coverImage: '/projects/test-cover.png',
+    screenshots: ['/projects/test-screenshot.png'],
+    repoUrl: 'https://github.com/test/test-project',
+    demoUrl: 'https://test-project.demo.com',
+    date: '2025-01-01',
+    status: 'stable',
+    highlighted: true,
+  },
+];
+
+/**
+ * Test function to validate JSON-LD schemas
+ */
+function testJsonLdSchemas() {
+  console.log('Testing JSON-LD schemas...\n');
+
+  try {
+    // Test homepage schema
+    const homepage = homepageJsonLd();
+    console.log(
+      '✅ Homepage JSON-LD:',
+      JSON.stringify(homepage, null, 2).substring(0, 100) + '...',
+    );
+
+    // Test blog page schema
+    const blogPage = blogPageJsonLd();
+    console.log(
+      '✅ Blog page JSON-LD:',
+      JSON.stringify(blogPage, null, 2).substring(0, 100) + '...',
+    );
+
+    // Test blog post schema
+    const blogPost = blogPostJsonLd(mockBlogPost);
+    console.log(
+      '✅ Blog post JSON-LD:',
+      JSON.stringify(blogPost, null, 2).substring(0, 100) + '...',
+    );
+
+    // Test projects page schema
+    const projectsPage = projectsPageJsonLd(mockProjects);
+    console.log(
+      '✅ Projects page JSON-LD:',
+      JSON.stringify(projectsPage, null, 2).substring(0, 100) + '...',
+    );
+
+    console.log('\n🎉 All JSON-LD schemas are valid!');
+  } catch (error) {
+    console.error('❌ Error in JSON-LD schemas:', error);
+  }
+}
+
+// Only run if this file is executed directly
+if (require.main === module) {
+  testJsonLdSchemas();
+}
+
+export { testJsonLdSchemas };

--- a/ui/src/lib/jsonld/utils.ts
+++ b/ui/src/lib/jsonld/utils.ts
@@ -1,0 +1,75 @@
+/**
+ * Utility functions for working with JSON-LD structured data
+ */
+
+/**
+ * Creates a basic Person schema for Juan Insuasti
+ */
+export const createPersonSchema = () => ({
+  '@type': 'Person',
+  name: 'Juan Insuasti',
+  url: 'https://insuasti.com/',
+  jobTitle: 'Frontend Developer',
+  knowsAbout: [
+    'React',
+    'TypeScript',
+    'Next.js',
+    'Frontend Development',
+    'Web Development',
+    'JavaScript',
+    'UI/UX Design',
+  ],
+});
+
+/**
+ * Creates a basic WebSite schema
+ */
+export const createWebsiteSchema = () => ({
+  '@type': 'WebSite',
+  name: 'Insuasti',
+  url: 'https://insuasti.com/',
+  author: createPersonSchema(),
+});
+
+/**
+ * Creates breadcrumb navigation for a given path
+ */
+export const createBreadcrumbSchema = (breadcrumbs: { name: string; url: string }[]) => ({
+  '@type': 'BreadcrumbList',
+  itemListElement: breadcrumbs.map((crumb, index) => ({
+    '@type': 'ListItem',
+    position: index + 1,
+    name: crumb.name,
+    item: crumb.url,
+  })),
+});
+
+/**
+ * Creates an image object schema
+ */
+export const createImageSchema = (url: string, width?: number, height?: number, alt?: string) => ({
+  '@type': 'ImageObject',
+  url,
+  ...(width && { width }),
+  ...(height && { height }),
+  ...(alt && { description: alt }),
+});
+
+/**
+ * Creates a basic organization schema
+ */
+export const createOrganizationSchema = () => ({
+  '@type': 'Organization',
+  name: 'Insuasti',
+  url: 'https://insuasti.com/',
+  founder: createPersonSchema(),
+});
+
+/**
+ * Standard base URLs for the site
+ */
+export const SITE_URLS = {
+  base: 'https://insuasti.com',
+  blog: 'https://insuasti.com/blog',
+  projects: 'https://insuasti.com/projects',
+} as const;


### PR DESCRIPTION
This pull request adds comprehensive JSON-LD structured data support across all major pages of the site, enhancing SEO and enabling richer search engine results. It introduces new JSON-LD schema generators for the homepage, blog listing, blog posts, and projects page, and integrates these schemas into the respective page components via a new `JsonLd` React component. Additionally, new sitemap and robots.txt generators are added for improved discoverability.

**Structured Data & SEO Enhancements**

* Introduced new JSON-LD schema generators for homepage (`homepageJsonLd`), blog listing (`blogPageJsonLd`), blog posts (`blogPostJsonLd`), and projects page (`projectsPageJsonLd`) in the `ui/src/lib/jsonld` directory. Each generator provides detailed schema.org metadata tailored to its page type. [[1]](diffhunk://#diff-9d2bfcf36542e2c06d1ff85808aafcbbfa00c9df63715312b48d87f69c1786c7R1-R155) [[2]](diffhunk://#diff-746fef78be4d855a0e727c18a5899f351bc41c2f38d36b8c140bd58255336656R1-R72) [[3]](diffhunk://#diff-758601275dd67d2f00d5ab656b7864d25878d2796e8f1feb72b6e8c050d76ab2R1-R114) [[4]](diffhunk://#diff-c127768acbbf417807b08cc575e609cff1712ce778bb299d78909bfc353c2acdR1-R20)
* Added a reusable `JsonLd` React component in `ui/src/components/JsonLd.tsx` for rendering JSON-LD structured data on pages, supporting both single and multiple schema objects.
* Updated all major page components (`page.tsx` for home, blog, blog post, and projects) to render their respective JSON-LD schemas using the new `JsonLd` component. [[1]](diffhunk://#diff-a124d8dc044213f810f44ff1b712948cce0a3055778e78a5345f15eb65434a81R8-R9) [[2]](diffhunk://#diff-a124d8dc044213f810f44ff1b712948cce0a3055778e78a5345f15eb65434a81R23) [ui/src/app/blog/[slug]/page.tsxR10-R11](diffhunk://#diff-3d22b67ba21fa39e7d261d767fdb4f6c1d05ff6b0b29d3bdbd61249b79ebb671R10-R11), [ui/src/app/blog/[slug]/page.tsxR75](diffhunk://#diff-3d22b67ba21fa39e7d261d767fdb4f6c1d05ff6b0b29d3bdbd61249b79ebb671R75), [[3]](diffhunk://#diff-3d406ae0e78978130fa4dae99eb8adcbdb0a509708bfcdd83b52bc7adf079b96R9-R10) [[4]](diffhunk://#diff-3d406ae0e78978130fa4dae99eb8adcbdb0a509708bfcdd83b52bc7adf079b96R101) [[5]](diffhunk://#diff-7df9d13364a24dd6913482a19ee6245e41bae44595adbd5304aedc5bff02c10cL5-R18) [[6]](diffhunk://#diff-7df9d13364a24dd6913482a19ee6245e41bae44595adbd5304aedc5bff02c10cR91-R95)

**Site Discoverability**

* Added a new sitemap generator in `ui/src/app/sitemap.ts` that outputs both static and dynamic routes (including all blog posts) for search engines.
* Added a new robots.txt generator in `ui/src/app/robots.ts` to allow all crawlers and point to the sitemap.

**Documentation**

* Added a detailed README in `ui/src/lib/jsonld/README.md` explaining the available JSON-LD schemas, usage examples, schema.org types, and validation best practices.

**Miscellaneous**

* Minor cleanup: removed the unused `themeColor` property from the site metadata in `ui/src/app/layout.tsx`.