### PR TITLE
feat(blog-content): add share to social media

### DIFF
--- a/ui/src/app/blog/[slug]/page.tsx
+++ b/ui/src/app/blog/[slug]/page.tsx
@@ -7,9 +7,10 @@ import { BlogPostCard } from '@features/blog/BlogPostCard';
 import { BlogPostContent } from '@features/blog/BlogPostContent';
 import { NavBar } from '@layout/navbar/NavBar';
 import { JsonLd } from '@ui/JsonLd';
+import { SocialLinks } from '@ui/SocialLinks';
 import { Typography } from '@ui/Typography';
 
-import { getAllPosts, getPostBySlug, getRelatedPosts } from '@lib/blog-utils';
+import { getAllPosts, getPostBySlug, getRelatedPosts, getSocialLinks } from '@lib/blog-utils';
 import { blogPostJsonLd } from '@lib/jsonld';
 import { renderMarkdown } from '@lib/markdown-utils';
 
@@ -93,10 +94,17 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
           {/* Blog post content */}
           <BlogPostContent post={post} htmlContent={htmlContent} />
 
+          {/* Share */}
+          <section className="mt-16 border-t border-border pt-16  mx-auto max-w-4xl">
+            <Typography as="h2" variant="h2" className="mb-8">
+              share
+            </Typography>
+            <SocialLinks socialLinks={getSocialLinks(post)} />
+          </section>
           {/* Related posts */}
           {relatedPosts.length > 0 && (
-            <section className="mt-16 border-t border-border pt-16">
-              <Typography as="h2" variant="h2" className="mb-8 text-center">
+            <section className="mt-16 border-t border-border pt-16  mx-auto max-w-4xl">
+              <Typography as="h2" variant="h2" className="mb-8">
                 Related Posts
               </Typography>
 

--- a/ui/src/components/ui/SocialLinks.tsx
+++ b/ui/src/components/ui/SocialLinks.tsx
@@ -3,10 +3,11 @@ import Link from 'next/link';
 
 import clsx from 'clsx';
 
-type SocialLink = {
+export type SocialLink = {
   href: string;
-  src: string;
+  src?: string;
   alt: string;
+  icon?: React.ReactNode;
 };
 
 export interface SocialProps {
@@ -21,10 +22,12 @@ export const SocialLinks = ({ className, socialLinks = [] }: SocialProps) => {
         <Link
           key={index}
           href={link.href}
+          aria-label={link.alt}
           target="_blank"
-          className="relative aspect-square h-14 md:h-16"
+          className={clsx('relative', link.src && 'aspect-square h-14 md:h-16')}
         >
-          <Image src={link.src} alt={link.alt} fill />
+          {link.src && <Image src={link.src} alt={link.alt} fill />}
+          {!link.src && link.icon}
         </Link>
       ))}
     </div>

--- a/ui/src/lib/blog-utils.tsx
+++ b/ui/src/lib/blog-utils.tsx
@@ -2,6 +2,11 @@ import fs from 'fs';
 import path from 'path';
 
 import matter from 'gray-matter';
+import { Linkedin } from 'lucide-react';
+import { siBluesky, siFacebook, siX } from 'simple-icons';
+
+import { SimpIcon } from '@ui/SimpIcon';
+import { SocialLink } from '@ui/SocialLinks';
 
 import { BlogPost, BlogPostMeta, PaginatedBlogPosts } from './blog-types';
 
@@ -213,3 +218,30 @@ export function getHighlightedPost(): BlogPostMeta | null {
   const randomIndex = Math.floor(Math.random() * highlightedPosts.length);
   return highlightedPosts[randomIndex];
 }
+
+// Gets social links to share post
+export const getSocialLinks = (post: BlogPostMeta): SocialLink[] => {
+  const url = `https://insuasti.com/blog/${post.slug}`;
+  return [
+    {
+      icon: <SimpIcon icon={siFacebook} />,
+      href: `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`,
+      alt: 'Share in Facebook',
+    },
+    {
+      icon: <Linkedin className="h-7 w-7" />,
+      href: `http://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(url)}`,
+      alt: 'Share in LinkedIn',
+    },
+    {
+      alt: 'Share in X',
+      icon: <SimpIcon icon={siX} />,
+      href: `https://x.com/intent/tweet?url=${encodeURIComponent(url)}`,
+    },
+    {
+      alt: 'Share in BlueSky',
+      icon: <SimpIcon icon={siBluesky} />,
+      href: `https://bsky.app/intent/compose?text=${encodeURIComponent(url)}`,
+    },
+  ];
+};


### PR DESCRIPTION
This pull request adds a new "Share" section to blog post pages, allowing users to easily share posts on multiple social platforms. It introduces a utility function to generate social sharing links, updates the `SocialLinks` component to support both icon and image-based links, and refactors related types and imports for better extensibility.

**Blog post page enhancements:**

* Added a "Share" section to the blog post page, displaying social sharing options using the `SocialLinks` component and links generated by the new `getSocialLinks` utility. ([ui/src/app/blog/[slug]/page.tsxR97-R107](diffhunk://#diff-3d22b67ba21fa39e7d261d767fdb4f6c1d05ff6b0b29d3bdbd61249b79ebb671R97-R107))

**Social sharing functionality:**

* Implemented the `getSocialLinks` function in `blog-utils.tsx` to generate platform-specific sharing URLs and icons for Facebook, LinkedIn, X (Twitter), and BlueSky.
* Updated the `SocialLinks` component to support both `src` (image) and `icon` (React node) props, and improved accessibility by adding `aria-label` to each link. [[1]](diffhunk://#diff-b41cb7b45ba8d2e4c5e26b4f5994a288a4a6c957c32fc19e9fcf0d4d8480e3ccL6-R10) [[2]](diffhunk://#diff-b41cb7b45ba8d2e4c5e26b4f5994a288a4a6c957c32fc19e9fcf0d4d8480e3ccR25-R30)

**Codebase improvements:**

* Refactored imports and type definitions to support new icon-based social links, including adding necessary icon libraries and updating relevant types.